### PR TITLE
Patch rust > 1.59 compilation issue

### DIFF
--- a/i586-rust_dos.json
+++ b/i586-rust_dos.json
@@ -4,7 +4,6 @@
     "data-layout": "e-m:e-p:32:32-f64:32:64-f80:32-n8:16:32-S128",
     "dynamic-linking": false,
     "executables": true,
-    "has-elf-tls": false,
     "has-rpath": true,
     "is-builtin": false,
     "linker-flavor": "ld.lld",

--- a/src/dos.rs
+++ b/src/dos.rs
@@ -3,6 +3,7 @@ pub mod console;
 pub mod panic;
 pub mod io;
 pub mod kbc;
+use core::arch::asm;
 
 pub fn exit(rt: u8) -> ! {
     unsafe {

--- a/src/dos/console.rs
+++ b/src/dos/console.rs
@@ -1,4 +1,5 @@
 use core::fmt::{self, Write};
+use core::arch::asm;
 
 #[macro_export]
 macro_rules! print {

--- a/src/dos/io.rs
+++ b/src/dos/io.rs
@@ -1,3 +1,5 @@
+use core::arch::asm;
+
 pub fn inb(port: usize) -> u8 {
     let mut ret: u8;
     unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(asm)]
 #![no_std]
 
 #[macro_use]


### PR DESCRIPTION
Since Rust 1.59, asm is considered stable.

Furthermore my compiler returned the following warning:
**warning: target json file contains unused fields: has-elf-tls**
So I removed this entry