### PR TITLE
Change the file example to work in DOSBox or real hardware

### DIFF
--- a/src/dos_tests/file.rs
+++ b/src/dos_tests/file.rs
@@ -2,26 +2,14 @@ use rust_dos::*;
 
 #[allow(dead_code)]
 pub(crate) fn file_read_test() {
-    let test_file = dos::file::File::open("test.txt").unwrap();
-    let mut buffer = [0; 20];
-    let bytes_read = test_file.read(&mut buffer).unwrap();
-    println!("{} bytes read", bytes_read);
-    println!("{}", core::str::from_utf8(&buffer).unwrap());
-    match test_file.close() {
-        Ok(_) => println!("File closed"),
-        Err(_) => println!("Error closing file")
-    }
-
-    let test_file = dos::file::File::open("C:\\AUTOEXEC.BAT").unwrap();
+    let test_file = dos::file::File::open("C:\\AUTOEXEC.BAT");
+    let test_file = test_file.unwrap_or(dos::file::File::open("README.md").unwrap());
     let mut buffer = [0; 100];
     let bytes_read = test_file.read(&mut buffer).unwrap();
     println!("{} bytes read", bytes_read);
     println!("{}", core::str::from_utf8(&buffer).unwrap());
-
     match test_file.close() {
         Ok(_) => println!("File closed"),
         Err(_) => println!("Error closing file")
     }
-
-    println!("Hello, World!");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,4 +15,6 @@ entry!(main);
 fn main() {
     allocator_test();
     file_read_test();
+
+    println!("Hello, World!");
 }


### PR DESCRIPTION
Basically, if AUTOEXEC.bat doesn't exist, try opening README.md.

Also, it seemed like the second example was the same just with a different file name so I removed it.